### PR TITLE
뷰포트 크기 - Context로 분리

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,11 +1,30 @@
+import React, { useState, useEffect } from "react";
+import { ViewSizeContext } from "./context";
+
 import "./App.css";
 import TransparentCard from "./animations/TransparentCard";
 
 function App() {
+    const [size, setSize] = useState({ width: 0, height: 0 });
+    const onResize = () => {
+        const { clientWidth: width, clientHeight: height } = document.body;
+        setSize({ width, height });
+    };
+    useEffect(() => {
+        onResize();
+        window.addEventListener("resize", onResize);
+        return () => {
+            window.removeEventListener("resize", onResize);
+        };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
     return (
+        <ViewSizeContext.Provider value={size}>
         <div className="App">
             <TransparentCard />
         </div>
+        </ViewSizeContext.Provider>
     );
 }
 

--- a/src/animations/Snowflake/Snowflake.jsx
+++ b/src/animations/Snowflake/Snowflake.jsx
@@ -1,14 +1,15 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useContext } from "react";
 import Canvas from "../../components/Canvas";
+import { ViewSizeContext } from "../../context";
+const Snowflake = props => {
+    const viewSize = useContext(ViewSizeContext);
 
-const Snowflake = () => {
     let flakes = [];
-    let width, height;
     let direction = -1; // -1: left, +1: right
     let prevPointer = 500;
 
     const addFlake = () => {
-        const x = Math.ceil(Math.random() * width);
+        const x = Math.ceil(Math.random() * viewSize.width);
         const r = Math.max(Math.ceil(Math.random() * 5), 2);
         const opacity = Math.min(Math.random() + 0.1, 0.7);
         flakes.push({ x, y: 0, r, opacity });
@@ -21,17 +22,12 @@ const Snowflake = () => {
             flake.x += gap * direction;
         });
         // 화면 바깥으로 나간 flake 제거
-        flakes = flakes.filter((flake) => flake.y < height);
+        flakes = flakes.filter((flake) => flake.y < viewSize.height);
     };
 
     const snow = () => {
         fallFlake();
         addFlake();
-    };
-
-    const setWidthHeight = () => {
-        width = document.body.clientWidth;
-        height = document.body.clientHeight;
     };
 
     const setDirectionFromCursorPosition = ({ x }) => {
@@ -41,13 +37,10 @@ const Snowflake = () => {
     };
 
     useEffect(() => {
-        setWidthHeight();
         const intervalId = setInterval(snow, 50);
-        window.addEventListener("resize", setWidthHeight);
         window.addEventListener("mousemove", setDirectionFromCursorPosition);
         return () => {
             clearInterval(intervalId);
-            window.removeEventListener("resize", setWidthHeight);
             window.removeEventListener(
                 "mousemove",
                 setDirectionFromCursorPosition
@@ -57,7 +50,7 @@ const Snowflake = () => {
 
     const draw = (ctx) => {
         ctx.fillStyle = "#1F2124";
-        ctx.fillRect(0, 0, width, height);
+        ctx.fillRect(0, 0, viewSize.width, viewSize.height);
 
         flakes.forEach((flake) => {
             ctx.beginPath();

--- a/src/components/Canvas/useCanvas.js
+++ b/src/components/Canvas/useCanvas.js
@@ -1,7 +1,9 @@
-import { useRef, useEffect } from "react";
+import { useRef, useEffect, useContext } from "react";
+import { ViewSizeContext } from "../../context";
 
 const useCanvas = (draw, dimension = "2d") => {
     const canvasRef = useRef(null);
+    const viewSize = useContext(ViewSizeContext);
 
     useEffect(() => {
         if (typeof draw !== "function") return;
@@ -24,23 +26,15 @@ const useCanvas = (draw, dimension = "2d") => {
     }, [draw, dimension]);
 
     useEffect(() => {
-        const resize = () => {
-            const { current: canvas } = canvasRef;
-            const context = canvas.getContext(dimension);
+        const { current: canvas } = canvasRef;
+        const context = canvas.getContext(dimension);
 
-            const { clientWidth: width, clientHeight: height } = document.body;
-            // 캔버스 더블 사이즈: 레티나 디스플레이 대응
-            canvas.width = width * 2;
-            canvas.height = height * 2;
-            context.scale(2, 2);
-        };
-        resize();
-
-        window.addEventListener("resize", resize);
-        return () => {
-            window.removeEventListener("resize", resize);
-        };
-    }, [dimension]);
+        const { width, height } = viewSize;
+        // 캔버스 더블 사이즈: 레티나 디스플레이 대응
+        canvas.width = width * 2;
+        canvas.height = height * 2;
+        context.scale(2, 2);
+    }, [viewSize, dimension]);
 
     return canvasRef;
 };

--- a/src/context.js
+++ b/src/context.js
@@ -1,0 +1,3 @@
+import { createContext } from "react";
+
+export const ViewSizeContext = createContext({ width: 0, height: 0 });


### PR DESCRIPTION
- 뷰포트 크기를 업데이트하는 `resize` 이벤트 핸들러가
   각 컴포넌트에 있어서 중복 코드가 많았는데
   Context API를 사용해서 `<App>`에서만 업데이트하도록 변경

- 문제 : 리렌더링이 일어나면서 캔버스도 다시 추가되고,
   데이터도 초기화되어서 애니메이션이 처음부터 시작됨.. 😱

### 다음 목표
- 화면 크기를 계산하는 코드는 지금처럼 중복되지 않도록 하되,
   리사이즈가 발생해도 애니메이션이 처음부터 시작해서는 안됨

   애니메이션과 관련된 데이터는 리액트 컴포넌트 바깥에 두어야..

   나중에 여러 기능을 각각의 페이지로 만들 때
   컴포넌트가 unmount 될 때(페이지 나갔을 때)에만 
   애니메이션의 데이터를 초기화하는 방식으로 고쳐야 할 듯